### PR TITLE
12.0 mig hw customer display

### DIFF
--- a/hw_customer_display/__init__.py
+++ b/hw_customer_display/__init__.py
@@ -1,0 +1,24 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Hardware Customer Display module for OpenERP
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+from . import controllers

--- a/hw_customer_display/__init__.py
+++ b/hw_customer_display/__init__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Hardware Customer Display module for Odoo

--- a/hw_customer_display/__init__.py
+++ b/hw_customer_display/__init__.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 ##############################################################################
 #
-#    Hardware Customer Display module for OpenERP
+#    Hardware Customer Display module for Odoo
 #    Copyright (C) 2014 Akretion (http://www.akretion.com)
 #    @author Alexis de Lattre <alexis.delattre@akretion.com>
 #

--- a/hw_customer_display/__manifest__.py
+++ b/hw_customer_display/__manifest__.py
@@ -82,4 +82,5 @@ This module has been written by Alexis de Lattre from Akretion
         'python': ['serial', 'unidecode'],
     },
     'data': [],
+    'installable':'False'
 }

--- a/hw_customer_display/__manifest__.py
+++ b/hw_customer_display/__manifest__.py
@@ -23,7 +23,7 @@
 
 {
     'name': 'Hardware Customer Display',
-    'version': '8.0.0.1.0',
+    'version': '12.0.0.1.0',
     'category': 'Hardware Drivers',
     'license': 'AGPL-3',
     'summary': 'Adds support for Customer Display in the Point of Sale',

--- a/hw_customer_display/__openerp__.py
+++ b/hw_customer_display/__openerp__.py
@@ -23,7 +23,7 @@
 
 {
     'name': 'Hardware Customer Display',
-    'version': '0.1',
+    'version': '8.0.0.1.0',
     'category': 'Hardware Drivers',
     'license': 'AGPL-3',
     'summary': 'Adds support for Customer Display in the Point of Sale',

--- a/hw_customer_display/__openerp__.py
+++ b/hw_customer_display/__openerp__.py
@@ -39,9 +39,16 @@ The configuration of the hardware is done in the configuration file of the Odoo 
 * customer_display_device_rate (default = 9600)
 * customer_display_device_timeout (default = 2 seconds)
 
-The number of rows and cols of the Customer Display (usually 2 x 20) should be configured on the main Odoo server, in the menu Point of Sale > Configuration > Point of Sales.
+The number of cols of the Customer Display (usually 20) should be configured on the main Odoo server, in the menu Point of Sale > Configuration > Point of Sales. The number of rows is supposed to be 2.
 
-It has been tested with a Bixolon BCD-1100 (http://www.bixolon.com/html/en/product/product_detail.xhtml?prod_id=61), but should support most serial and USB-serial LCD displays out-of-the-box or with inheritance of a few functions. To setup the BCD-1100 on Linux, you will find some technical instructions on this page : http://techtuxwords.blogspot.fr/2012/12/linux-and-bixolon-bcd-1100.html
+It should support most serial and USB-serial LCD displays out-of-the-box or with inheritance of a few functions.
+
+It has been tested with:
+
+* Bixolon BCD-1100 (Datasheet : http://www.bixolon.com/html/en/product/product_detail.xhtml?prod_id=61)
+* Bixolon BCD-1000
+
+To setup the BCD-1100 on Linux, you will find some technical instructions on this page : http://techtuxwords.blogspot.fr/2012/12/linux-and-bixolon-bcd-1100.html
 
 This module has been developped during a POS code sprint at Akretion France from July 7th to July 10th 2014. This module is part of the POS project of the Odoo Community Association http://odoo-community.org/. You are invited to become a member and/or get involved in the Association !
 

--- a/hw_customer_display/__openerp__.py
+++ b/hw_customer_display/__openerp__.py
@@ -49,6 +49,7 @@ It has been tested with:
 * Bixolon BCD-1000
 
 To setup the BCD-1100 on Linux, you will find some technical instructions on this page : http://techtuxwords.blogspot.fr/2012/12/linux-and-bixolon-bcd-1100.html
+If you have a kernel >= 3.12, you should also read this : http://www.leniwiec.org/en/2014/06/25/ubuntu-14-04lts-how-to-pass-id-vendor-and-id-product-to-ftdi_sio-driver/
 
 This module has been developped during a POS code sprint at Akretion France from July 7th to July 10th 2014. This module is part of the POS project of the Odoo Community Association http://odoo-community.org/. You are invited to become a member and/or get involved in the Association !
 

--- a/hw_customer_display/__openerp__.py
+++ b/hw_customer_display/__openerp__.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 ##############################################################################
 #
-#    Hardware Customer Display module for OpenERP
+#    Hardware Customer Display module for Odoo
 #    Copyright (C) 2014 Akretion (http://www.akretion.com)
 #    @author Alexis de Lattre <alexis.delattre@akretion.com>
 #
@@ -26,22 +26,24 @@
     'version': '0.1',
     'category': 'Hardware Drivers',
     'license': 'AGPL-3',
-    'summary': 'Adds a support for Customer LCD in Point of Sale',
+    'summary': 'Adds support for Customer Display in the Point of Sale',
     'description': """
 Hardware Customer Display
 =========================
 
-This module adds support for Customer Display in the Point of Sale. It has been tested with a Bixolon BCD-1100 (http://www.bixolon.com/html/en/product/product_detail.xhtml?prod_id=61), but should support most serial and USB-serial LCD displays out-of-the-box or with inheritance of a few functions. This module is designed to be installed on the *POSbox* (i.e. the proxy on which the USB devices are connected) and not on the Odoo server.
+This module adds support for Customer Display in the Point of Sale. This module is designed to be installed on the *POSbox* (i.e. the proxy on which the USB devices are connected) and not on the main Odoo server. On the main Odoo server, you should install the module *pos_customer_display*.
 
 The configuration of the hardware is done in the configuration file of the Odoo server of the POSbox. You should add the following entries in the configuration file:
 
 * customer_display_device_name (default = /dev/ttyUSB0)
 * customer_display_device_rate (default = 9600)
 * customer_display_device_timeout (default = 2 seconds)
-* customer_display_device_rows (default = 2)
-* customer_display_device_cols (default = 20)
 
-This module has been developped during a POS code sprint at Akretion France from July 7th to July 10th 2014.
+The number of rows and cols of the Customer Display (usually 2 x 20) should be configured on the main Odoo server, in the menu Point of Sale > Configuration > Point of Sales.
+
+It has been tested with a Bixolon BCD-1100 (http://www.bixolon.com/html/en/product/product_detail.xhtml?prod_id=61), but should support most serial and USB-serial LCD displays out-of-the-box or with inheritance of a few functions. To setup the BCD-1100 on Linux, you will find some technical instructions on this page : http://techtuxwords.blogspot.fr/2012/12/linux-and-bixolon-bcd-1100.html
+
+This module has been developped during a POS code sprint at Akretion France from July 7th to July 10th 2014. This module is part of the POS project of the Odoo Community Association http://odoo-community.org/. You are invited to become a member and/or get involved in the Association !
 
 Please contact Alexis de Lattre from Akretion <alexis.delattre@akretion.com> for any help or question about this module.
     """,

--- a/hw_customer_display/__openerp__.py
+++ b/hw_customer_display/__openerp__.py
@@ -75,7 +75,7 @@ Association !
 This module has been written by Alexis de Lattre from Akretion
 <alexis.delattre@akretion.com>.
     """,
-    'author': 'Akretion',
+    'author': "Akretion,Odoo Community Association (OCA)",
     'website': 'http://www.akretion.com',
     'depends': ['hw_proxy'],
     'external_dependencies': {

--- a/hw_customer_display/__openerp__.py
+++ b/hw_customer_display/__openerp__.py
@@ -1,0 +1,56 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Hardware Customer Display module for OpenERP
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+{
+    'name': 'Hardware Customer Display',
+    'version': '0.1',
+    'category': 'Hardware Drivers',
+    'license': 'AGPL-3',
+    'summary': 'Adds a support for Customer LCD in Point of Sale',
+    'description': """
+Hardware Customer Display
+=========================
+
+This module adds support for Customer Display in the Point of Sale. It has been tested with a Bixolon BCD-1100 (http://www.bixolon.com/html/en/product/product_detail.xhtml?prod_id=61), but should support most serial and USB-serial LCD displays out-of-the-box or with inheritance of a few functions. This module is designed to be installed on the *POSbox* (i.e. the proxy on which the USB devices are connected) and not on the Odoo server.
+
+The configuration of the hardware is done in the configuration file of the Odoo server of the POSbox. You should add the following entries in the configuration file:
+
+* customer_display_device_name (default = /dev/ttyUSB0)
+* customer_display_device_rate (default = 9600)
+* customer_display_device_timeout (default = 2 seconds)
+* customer_display_device_rows (default = 2)
+* customer_display_device_cols (default = 20)
+
+This module has been developped during a POS code sprint at Akretion France from July 7th to July 10th 2014.
+
+Please contact Alexis de Lattre from Akretion <alexis.delattre@akretion.com> for any help or question about this module.
+    """,
+    'author': 'Akretion',
+    'website': 'http://www.akretion.com',
+    'depends': ['hw_proxy'],
+    'external_dependencies': {
+        'python' : ['serial', 'unidecode'],
+    },
+    'data': [],
+    'active': False,
+}

--- a/hw_customer_display/__openerp__.py
+++ b/hw_customer_display/__openerp__.py
@@ -62,5 +62,4 @@ Please contact Alexis de Lattre from Akretion <alexis.delattre@akretion.com> for
         'python': ['serial', 'unidecode'],
     },
     'data': [],
-    'active': False,
 }

--- a/hw_customer_display/__openerp__.py
+++ b/hw_customer_display/__openerp__.py
@@ -31,29 +31,49 @@
 Hardware Customer Display
 =========================
 
-This module adds support for Customer Display in the Point of Sale. This module is designed to be installed on the *POSbox* (i.e. the proxy on which the USB devices are connected) and not on the main Odoo server. On the main Odoo server, you should install the module *pos_customer_display*.
+This module adds support for Customer Display in the Point of Sale.
+This module is designed to be installed on the *POSbox* (i.e. the
+proxy on which the USB devices are connected) and not on the main
+Odoo server. On the main Odoo server, you should install the module
+*pos_customer_display*.
 
-The configuration of the hardware is done in the configuration file of the Odoo server of the POSbox. You should add the following entries in the configuration file:
+The configuration of the hardware is done in the configuration file of
+the Odoo server of the POSbox. You should add the following entries in
+the configuration file:
 
 * customer_display_device_name (default = /dev/ttyUSB0)
 * customer_display_device_rate (default = 9600)
 * customer_display_device_timeout (default = 2 seconds)
 
-The number of cols of the Customer Display (usually 20) should be configured on the main Odoo server, in the menu Point of Sale > Configuration > Point of Sales. The number of rows is supposed to be 2.
+The number of cols of the Customer Display (usually 20) should be
+configured on the main Odoo server, in the menu Point of Sale >
+Configuration > Point of Sales. The number of rows is supposed to be 2.
 
-It should support most serial and USB-serial LCD displays out-of-the-box or with inheritance of a few functions.
+It should support most serial and USB-serial LCD displays out-of-the-box
+or with inheritance of a few functions.
 
 It has been tested with:
 
-* Bixolon BCD-1100 (Datasheet : http://www.bixolon.com/html/en/product/product_detail.xhtml?prod_id=61)
+* Bixolon BCD-1100 (Datasheet :
+  http://www.bixolon.com/html/en/product/product_detail.xhtml?prod_id=61)
 * Bixolon BCD-1000
 
-To setup the BCD-1100 on Linux, you will find some technical instructions on this page : http://techtuxwords.blogspot.fr/2012/12/linux-and-bixolon-bcd-1100.html
-If you have a kernel >= 3.12, you should also read this : http://www.leniwiec.org/en/2014/06/25/ubuntu-14-04lts-how-to-pass-id-vendor-and-id-product-to-ftdi_sio-driver/
+To setup the BCD-1100 on Linux, you will find some technical instructions
+on this page:
+http://techtuxwords.blogspot.fr/2012/12/linux-and-bixolon-bcd-1100.html
 
-This module has been developped during a POS code sprint at Akretion France from July 7th to July 10th 2014. This module is part of the POS project of the Odoo Community Association http://odoo-community.org/. You are invited to become a member and/or get involved in the Association !
+If you have a kernel >= 3.12, you should also read this:
+http://www.leniwiec.org/en/2014/06/25/ubuntu-14-04lts-how-to-pass-id-ven
+dor-and-id-product-to-ftdi_sio-driver/
 
-Please contact Alexis de Lattre from Akretion <alexis.delattre@akretion.com> for any help or question about this module.
+This module has been developped during a POS code sprint at Akretion
+France from July 7th to July 10th 2014. This module is part of the POS
+project of the Odoo Community Association http://odoo-community.org/.
+You are invited to become a member and/or get involved in the
+Association !
+
+This module has been written by Alexis de Lattre from Akretion
+<alexis.delattre@akretion.com>.
     """,
     'author': 'Akretion',
     'website': 'http://www.akretion.com',

--- a/hw_customer_display/__openerp__.py
+++ b/hw_customer_display/__openerp__.py
@@ -51,7 +51,7 @@ Please contact Alexis de Lattre from Akretion <alexis.delattre@akretion.com> for
     'website': 'http://www.akretion.com',
     'depends': ['hw_proxy'],
     'external_dependencies': {
-        'python' : ['serial', 'unidecode'],
+        'python': ['serial', 'unidecode'],
     },
     'data': [],
     'active': False,

--- a/hw_customer_display/controllers/__init__.py
+++ b/hw_customer_display/controllers/__init__.py
@@ -1,0 +1,24 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Hardware Customer Display module for OpenERP
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+from . import main

--- a/hw_customer_display/controllers/__init__.py
+++ b/hw_customer_display/controllers/__init__.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 ##############################################################################
 #
-#    Hardware Customer Display module for OpenERP
+#    Hardware Customer Display module for Odoo
 #    Copyright (C) 2014 Akretion (http://www.akretion.com)
 #    @author Alexis de Lattre <alexis.delattre@akretion.com>
 #

--- a/hw_customer_display/controllers/main.py
+++ b/hw_customer_display/controllers/main.py
@@ -174,5 +174,7 @@ class CustomerDisplayProxy(hw_proxy.Proxy):
         '/hw_proxy/send_text_customer_display', type='json', auth='none',
         cors='*')
     def send_text_customer_display(self, text_to_display):
-        logger.debug('LCD: Call send_text_customer_display')
+        logger.debug(
+            'LCD: Call send_text_customer_display with text=%s',
+            text_to_display)
         driver.push_task('display', text_to_display)

--- a/hw_customer_display/controllers/main.py
+++ b/hw_customer_display/controllers/main.py
@@ -73,9 +73,9 @@ class CustomerDisplayDriver(Thread):
                 self.status['messages'] = []
 
         if status == 'error' and message:
-            logger.error('Display Error: '+message)
+            logger.error('Display Error: ' + message)
         elif status == 'disconnected' and message:
-            logger.warning('Disconnected Display: '+message)
+            logger.warning('Disconnected Display: ' + message)
 
     def lockedstart(self):
         with self.lock:
@@ -102,23 +102,23 @@ class CustomerDisplayDriver(Thread):
             self.serial_write(unidecode(line).encode('ascii'))
 
     def setup_customer_display(self):
-        '''Set LCD cursor to off
+        """Set LCD cursor to off
         If your LCD has different setup instruction(s), you should
-        inherit this function'''
+        inherit this function"""
         # Bixolon spec : 35. "Set Cursor On/Off"
         self.cmd_serial_write(CURSOR_OFF)
         logger.debug('LCD cursor set to off')
 
     def clear_customer_display(self):
-        '''If your LCD has different clearing instruction, you should inherit
-        this function'''
+        """If your LCD has different clearing instruction, you should inherit
+        this function"""
         # Bixolon spec : 12. "Clear Display Screen and Clear String Mode"
         self.cmd_serial_write(CLEAR_DISPLAY)
         logger.debug('Customer display cleared')
 
     def cmd_serial_write(self, command):
-        '''If your LCD requires a prefix and/or suffix on all commands,
-        you should inherit this function'''
+        """If your LCD requires a prefix and/or suffix on all commands,
+        you should inherit this function"""
         assert isinstance(command, bytes), 'command must be a bytes string'
         self.serial_write(command)
 
@@ -127,7 +127,7 @@ class CustomerDisplayDriver(Thread):
         self.serial.write(text)
 
     def send_text_customer_display(self, text_to_display):
-        '''This function sends the data to the serial/usb port.
+        """This function sends the data to the serial/usb port.
         We open and close the serial connection on every message display.
         Why ?
         1. Because it is not a problem for the customer display
@@ -135,7 +135,7 @@ class CustomerDisplayDriver(Thread):
         3. Because it allows recovery on errors : you can unplug/replug the
         customer display and it will work again on the next message without
         problem
-        '''
+        """
         lines = simplejson.loads(text_to_display)
         assert isinstance(lines, list), 'lines_list should be a list'
         try:
@@ -163,7 +163,15 @@ class CustomerDisplayDriver(Thread):
                 if task == 'display':
                     self.send_text_customer_display(data)
                 elif task == 'status':
-                    pass
+                    serial = Serial(
+                        self.device_name, self.device_rate,
+                        timeout=self.device_timeout)
+                    if serial.isOpen():
+                        self.set_status(
+                            'connected',
+                            'Connected to %s' % self.device_name
+                        )
+                        self.serial = serial
             except Exception as e:
                 self.set_status('error', str(e))
 

--- a/hw_customer_display/controllers/main.py
+++ b/hw_customer_display/controllers/main.py
@@ -1,0 +1,182 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Hardware Customer Display module for OpenERP
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+import logging
+import simplejson
+import time
+from threading import Thread, Lock
+from Queue import Queue
+from unidecode import unidecode
+from serial import Serial
+import openerp.addons.hw_proxy.controllers.main as hw_proxy
+from openerp import http
+from openerp.tools.config import config
+
+
+logger = logging.getLogger(__name__)
+
+
+class CustomerDisplayDriver(Thread):
+    def __init__(self):
+        Thread.__init__(self)
+        self.queue = Queue()
+        self.lock = Lock()
+        self.status = {'status': 'connecting', 'messages': []}
+        self.device_name = config.get(
+            'customer_display_device_name', '/dev/ttyUSB0')
+        self.device_rate = int(config.get(
+            'customer_display_device_rate', 9600))
+        self.device_timeout = int(config.get(
+            'customer_display_device_timeout', 2))
+        self.device_rows = int(config.get(
+            'customer_display_device_rows', 2))
+        self.device_cols = int(config.get(
+            'customer_display_device_cols', 20))
+        self.serial = False
+
+    def get_status(self):
+        self.push_task('status')
+        return self.status
+
+    def set_status(self, status, message=None):
+        if status == self.status['status']:
+            if message is not None and message != self.status['messages'][-1]:
+                self.status['messages'].append(message)
+        else:
+            self.status['status'] = status
+            if message:
+                self.status['messages'] = [message]
+            else:
+                self.status['messages'] = []
+
+        if status == 'error' and message:
+            logger.error('Display Error: '+message)
+        elif status == 'disconnected' and message:
+            logger.warning('Disconnected Display: '+message)
+
+    def lockedstart(self):
+        with self.lock:
+            if not self.isAlive():
+                self.daemon = True
+                self.start()
+
+    def push_task(self, task, data=None):
+        self.lockedstart()
+        self.queue.put((time.time(), task, data))
+
+    def move_cursor(self, col, row):
+        # Bixolon spec : 11. "Move Cursor to Specified Position"
+        self.cmd_serial_write('\x1B\x6C' + chr(col) + chr(row))
+
+    def display_text(self, lines):
+        logger.debug(
+            "Preparing to send the following lines to LCD: %s" % lines)
+        if len(lines) > self.device_rows:
+            logger.error(
+                'Odoo POS sends %d rows but LCD only has %d rows'
+                % (len(lines), self.device_rows))
+            return
+        assert len(lines) <= self.device_rows, 'Too many lines'
+        lines_ascii = []
+        for line in lines:
+            lines_ascii.append(unidecode(line))
+        row = 0
+        for dline in lines_ascii:
+            row += 1
+            self.move_cursor(1, row)
+            if len(line) > self.device_cols:
+                logger.error(
+                    'Odoo POS sends %d characters but LCD only has %d cols'
+                    % (len(line), self.device_cols))
+                return
+            self.serial_write(dline)
+
+    def setup_customer_display(self):
+        '''Set LCD cursor to off
+        If your LCD has different setup instruction(s), you should
+        inherit this function'''
+        # Bixolon spec : 35. "Set Cursor On/Off"
+        self.cmd_serial_write('\x1F\x43\x00')
+        logger.debug('LCD cursor set to off')
+
+    def clear_customer_display(self):
+        '''If your LCD has different clearing instruction, you should inherit
+        this function'''
+        # Bixolon spec : 12. "Clear Display Screen and Clear String Mode"
+        self.cmd_serial_write('\x0C')
+        logger.debug('Customer display cleared')
+
+    def cmd_serial_write(self, command):
+        '''If your LCD requires a prefix and/or suffix on all commands,
+        you should inherit this function'''
+        assert isinstance(command, str), 'command must be a string'
+        self.serial_write(command)
+
+    def serial_write(self, text):
+        assert isinstance(text, str), 'text must be a string'
+        self.serial.write(text)
+
+    def send_text_customer_display(self, text_to_display):
+        lines = simplejson.loads(text_to_display)
+        assert isinstance(lines, list), 'lines_list should be a list'
+        try:
+            logger.debug(
+                'Opening serial port %s for customer display with baudrate %d'
+                % (self.device_name, self.device_rate))
+            self.serial = Serial(
+                self.device_name, self.device_rate,
+                timeout=self.device_timeout)
+            logger.debug('serial.is_open = %s' % self.serial.isOpen())
+            self.setup_customer_display()
+            self.clear_customer_display()
+            self.display_text(lines)
+        except Exception, e:
+            logger.error('Exception in serial connection: %s' % str(e))
+        finally:
+            if self.serial:
+                logger.debug('Closing serial port for customer display')
+                self.serial.close()
+
+    def run(self):
+        while True:
+            try:
+                timestamp, task, data = self.queue.get(True)
+                if task == 'display':
+                    self.send_text_customer_display(data)
+                elif task == 'status':
+                    pass
+            except Exception as e:
+                self.set_status('error', str(e))
+
+driver = CustomerDisplayDriver()
+
+hw_proxy.drivers['customer_display'] = driver
+
+
+class CustomerDisplayProxy(hw_proxy.Proxy):
+    @http.route(
+        '/hw_proxy/send_text_customer_display', type='json', auth='none',
+        cors='*')
+    def send_text_customer_display(self, text_to_display):
+        logger.debug('LCD: Call send_text_customer_display')
+        driver.push_task('display', text_to_display)

--- a/hw_customer_display/controllers/main.py
+++ b/hw_customer_display/controllers/main.py
@@ -167,6 +167,7 @@ class CustomerDisplayDriver(Thread):
             except Exception as e:
                 self.set_status('error', str(e))
 
+
 driver = CustomerDisplayDriver()
 
 hw_proxy.drivers['customer_display'] = driver

--- a/hw_customer_display/controllers/main.py
+++ b/hw_customer_display/controllers/main.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 CLEAR_DISPLAY = b'\x0C'
 MOVE_CURSOR_TO = b'\x1B\x6C'
-CURSOR_OFF = b'\x1F\x5F\x00'
+CURSOR_OFF = b'\x1F\x43\x00'
 
 try:
     from serial import Serial

--- a/hw_customer_display/controllers/main.py
+++ b/hw_customer_display/controllers/main.py
@@ -39,6 +39,12 @@ except (ImportError, IOError) as err:
     logger.debug(err)
 
 
+try:
+    from unidecode import unidecode
+except ImportError:
+    logger.info('`unidecode` Python pacakge not found')
+
+
 class CustomerDisplayDriver(Thread):
     def __init__(self):
         Thread.__init__(self)

--- a/hw_customer_display/controllers/main.py
+++ b/hw_customer_display/controllers/main.py
@@ -39,12 +39,6 @@ except (ImportError, IOError) as err:
     logger.debug(err)
 
 
-try:
-    from unidecode import unidecode
-except ImportError:
-    logger.info('`unidecode` Python pacakge not found')
-
-
 class CustomerDisplayDriver(Thread):
     def __init__(self):
         Thread.__init__(self)

--- a/hw_customer_display/controllers/main.py
+++ b/hw_customer_display/controllers/main.py
@@ -26,14 +26,17 @@ import simplejson
 import time
 from threading import Thread, Lock
 from Queue import Queue
-from unidecode import unidecode
-from serial import Serial
 import openerp.addons.hw_proxy.controllers.main as hw_proxy
 from openerp import http
 from openerp.tools.config import config
 
-
 logger = logging.getLogger(__name__)
+
+try:
+    from serial import Serial
+    from unidecode import unidecode
+except (ImportError, IOError) as err:
+    logger.debug(err)
 
 
 class CustomerDisplayDriver(Thread):

--- a/hw_customer_display/controllers/main.py
+++ b/hw_customer_display/controllers/main.py
@@ -22,13 +22,16 @@
 
 
 import logging
-import simplejson
+import json as simplejson
 import time
 from threading import Thread, Lock
-from Queue import Queue
-import openerp.addons.hw_proxy.controllers.main as hw_proxy
-from openerp import http
-from openerp.tools.config import config
+try:
+    from queue import Queue
+except ImportError:
+    from Queue import Queue
+import odoo.addons.hw_proxy.controllers.main as hw_proxy
+from odoo import http
+from odoo.tools.config import config
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +98,7 @@ class CustomerDisplayDriver(Thread):
         lines_ascii = []
         for line in lines:
             lines_ascii.append(unidecode(line))
+
         row = 0
         for dline in lines_ascii:
             row += 1
@@ -149,7 +153,7 @@ class CustomerDisplayDriver(Thread):
             self.setup_customer_display()
             self.clear_customer_display()
             self.display_text(lines)
-        except Exception, e:
+        except Exception as e:
             logger.error('Exception in serial connection: %s' % str(e))
         finally:
             if self.serial:

--- a/hw_customer_display/i18n/hw_customer_display.pot
+++ b/hw_customer_display/i18n/hw_customer_display.pot
@@ -1,0 +1,14 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+

--- a/hw_customer_display/test-scripts/customer-display-test.py
+++ b/hw_customer_display/test-scripts/customer-display-test.py
@@ -1,0 +1,68 @@
+#! /usr/bin/python
+# -*- encoding: utf-8 -*-
+# Author : Alexis de Lattre <alexis.delattre@akretion.com>
+# The licence is in the file __openerp__.py
+# This is a test script, that you can use if you want to test/play
+# with the customer display independantly from the Odoo server
+# It has been tested with a Bixolon BCD-1100
+
+from serial import Serial
+from unidecode import unidecode
+import sys
+
+DEVICE = '/dev/ttyUSB0'
+DEVICE_RATE = 9600
+DEVICE_COLS = 20
+
+
+def display_text(ser, line1, line2):
+    print "convert to ascii"
+    line1 = unidecode(line1)
+    line2 = unidecode(line2)
+    print "set lines to the right lenght (%s)" % DEVICE_COLS
+    for line in [line1, line2]:
+        if len(line) < DEVICE_COLS:
+            line += ' ' * (DEVICE_COLS - len(line))
+        elif len(line) > DEVICE_COLS:
+            line = line[0:DEVICE_COLS]
+        assert len(line) == DEVICE_COLS, 'Wrong length'
+    print "try to clear display"
+    ser.write('\x0C')
+    print "clear done"
+    print "try to position at start of 1st line"
+    ser.write('\x1B\x6C' + chr(1) + chr(1))
+    print "position done"
+    print "try to write 1st line"
+    ser.write(line1)
+    print "write 1st line done"
+    print "try to position at start of 2nd line"
+    ser.write('\x1B\x6C' + chr(1) + chr(2))
+    print "position done"
+    print "try to write 2nd line"
+    ser.write(line2)
+    print "write done"
+
+
+def open_close_display(line1, line2):
+    ser = False
+    try:
+        print "open serial port"
+        ser = Serial(DEVICE, DEVICE_RATE, timeout=2)
+        print "serial port open =", ser.isOpen()
+        print "try to set cursor to off"
+        ser.write('\x1F\x43\x00')
+        print "cursor set to off"
+        display_text(ser, line1, line2)
+    except Exception, e:
+        print "EXCEPTION e=", e
+        sys.exit(1)
+    finally:
+        if ser:
+            print "close serial port"
+            ser.close()
+
+
+if __name__ == '__main__':
+    line1 = u'POS Code Sprint'
+    line2 = u'@ Akretion 2014/07'
+    open_close_display(line1, line2)

--- a/hw_customer_display/test-scripts/customer-display-test.py
+++ b/hw_customer_display/test-scripts/customer-display-test.py
@@ -23,7 +23,7 @@ DEVICE_COLS = 20
 
 CLEAR_DISPLAY = b'\x0C'
 MOVE_CURSOR_TO = b'\x1B\x6C'
-CURSOR_OFF = b'\x1F\x5F\x00'
+CURSOR_OFF = b'\x1F\x43\x00'
 
 
 def display_text(ser, line1, line2):

--- a/hw_customer_display/test-scripts/customer-display-test.py
+++ b/hw_customer_display/test-scripts/customer-display-test.py
@@ -17,17 +17,17 @@ try:
 except (ImportError, IOError) as err:
     _logger.debug(err)
 
-DEVICE = '/dev/ttyUSB0'
+DEVICE = '/dev/bixolon'
 DEVICE_RATE = 9600
 DEVICE_COLS = 20
 
 CLEAR_DISPLAY = b'\x0C'
 MOVE_CURSOR_TO = b'\x1B\x6C'
-
+CURSOR_OFF = b'\x1F\x5F\x00'
 
 
 def display_text(ser, line1, line2):
-    print("set lines to the right length (%s)" % DEVICE_COLS)
+    print(("set lines to the right length (%s)" % DEVICE_COLS))
     for line in [line1, line2]:
         if len(line) < DEVICE_COLS:
             line += ' ' * (DEVICE_COLS - len(line))
@@ -59,14 +59,14 @@ def open_close_display(line1, line2):
     try:
         print("open serial port")
         ser = Serial(DEVICE, DEVICE_RATE, timeout=2)
-        print("serial port open =", ser.isOpen())
-        print("serial name =", ser.name)
+        print(("serial port open =", ser.isOpen()))
+        print(("serial name =", ser.name))
         print("try to set cursor to off")
-        ser.write(b'\x1F\x43\x00')
+        ser.write(CURSOR_OFF)
         print("cursor set to off")
         display_text(ser, line1, line2)
     except Exception as e:
-        print('EXCEPTION e={}'.format(e))
+        print(('EXCEPTION e={}'.format(e)))
         sys.exit(1)
     finally:
         if ser:
@@ -75,6 +75,6 @@ def open_close_display(line1, line2):
 
 
 if __name__ == '__main__':
-    line1 = u'Coop IT Easy'
-    line2 = u'Migration to 12.0'
+    line1 = 'Coop IT Easy'
+    line2 = 'Migration to 12.0'
     open_close_display(line1, line2)

--- a/hw_customer_display/test-scripts/customer-display-test.py
+++ b/hw_customer_display/test-scripts/customer-display-test.py
@@ -6,9 +6,16 @@
 # with the customer display independantly from the Odoo server
 # It has been tested with a Bixolon BCD-1100
 
-from serial import Serial
-from unidecode import unidecode
 import sys
+import logging
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from serial import Serial
+    from unidecode import unidecode
+except (ImportError, IOError) as err:
+    _logger.debug(err)
 
 DEVICE = '/dev/ttyUSB0'
 DEVICE_RATE = 9600

--- a/hw_customer_display/test-scripts/customer-display-test.py
+++ b/hw_customer_display/test-scripts/customer-display-test.py
@@ -1,7 +1,6 @@
-#! /usr/bin/python
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # Author : Alexis de Lattre <alexis.delattre@akretion.com>
-# The licence is in the file __openerp__.py
+# The licence is in the file __manifest__.py
 # This is a test script, that you can use if you want to test/play
 # with the customer display independantly from the Odoo server
 # It has been tested with a Bixolon BCD-1100
@@ -23,49 +22,54 @@ DEVICE_COLS = 20
 
 
 def display_text(ser, line1, line2):
-    print "convert to ascii"
+    print("before = ", line1)
+    print("before = ", line2)
+    print("convert to ascii")
     line1 = unidecode(line1)
     line2 = unidecode(line2)
-    print "set lines to the right lenght (%s)" % DEVICE_COLS
+    print("after = ", line1)
+    print("after = ", line2)
+    print("set lines to the right length (%s)" % DEVICE_COLS)
     for line in [line1, line2]:
         if len(line) < DEVICE_COLS:
             line += ' ' * (DEVICE_COLS - len(line))
         elif len(line) > DEVICE_COLS:
             line = line[0:DEVICE_COLS]
         assert len(line) == DEVICE_COLS, 'Wrong length'
-    print "try to clear display"
-    ser.write('\x0C')
-    print "clear done"
-    print "try to position at start of 1st line"
-    ser.write('\x1B\x6C' + chr(1) + chr(1))
-    print "position done"
-    print "try to write 1st line"
-    ser.write(line1)
-    print "write 1st line done"
-    print "try to position at start of 2nd line"
-    ser.write('\x1B\x6C' + chr(1) + chr(2))
-    print "position done"
-    print "try to write 2nd line"
-    ser.write(line2)
-    print "write done"
+    print("try to clear display")
+    ser.write(b'\x0C')
+    print("clear done")
+    print("try to position at start of 1st line")
+    ser.write(b'\x1B\x6C' + bytes(1) + bytes(1))
+    print("position done")
+    print("try to write 1st line")
+    ser.write(line1.encode())
+    print("write 1st line done")
+    print("try to position at start of 2nd line")
+    ser.write(b'\x1B\x6C' + bytes(1) + bytes(2))
+    print("position done")
+    print("try to write 2nd line")
+    ser.write(line2.encode())
+    print("write done")
 
 
 def open_close_display(line1, line2):
     ser = False
     try:
-        print "open serial port"
+        print("open serial port")
         ser = Serial(DEVICE, DEVICE_RATE, timeout=2)
-        print "serial port open =", ser.isOpen()
-        print "try to set cursor to off"
-        ser.write('\x1F\x43\x00')
-        print "cursor set to off"
+        print("serial port open =", ser.isOpen())
+        print("serial name =", ser.name)
+        print("try to set cursor to off")
+        ser.write(b'\x1F\x43\x00')
+        print("cursor set to off")
         display_text(ser, line1, line2)
-    except Exception, e:
-        print "EXCEPTION e=", e
+    except Exception as e:
+        print('EXCEPTION e={}'.format(e))
         sys.exit(1)
     finally:
         if ser:
-            print "close serial port"
+            print("close serial port")
             ser.close()
 
 

--- a/hw_customer_display/test-scripts/customer-display-test.py
+++ b/hw_customer_display/test-scripts/customer-display-test.py
@@ -7,6 +7,7 @@
 
 import sys
 import logging
+import time
 
 _logger = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ try:
 except (ImportError, IOError) as err:
     _logger.debug(err)
 
-DEVICE = '/dev/ttyUSB0'
+DEVICE = '/dev/ttyUSB1'
 DEVICE_RATE = 9600
 DEVICE_COLS = 20
 
@@ -40,18 +41,21 @@ def display_text(ser, line1, line2):
     ser.write(b'\x0C')
     print("clear done")
     print("try to position at start of 1st line")
-    ser.write(b'\x1B\x6C' + bytes(1) + bytes(1))
+    l1 = '\x1B\x6C' + chr(1) + chr(1)
+    print(l1)
+    ser.write(l1.encode())
     print("position done")
     print("try to write 1st line")
     ser.write(line1.encode())
     print("write 1st line done")
+    time.sleep(1)
     print("try to position at start of 2nd line")
-    ser.write(b'\x1B\x6C' + bytes(1) + bytes(2))
+    l2 = '\x1B\x6C' + chr(1) + chr(2)
+    ser.write(l2.encode())
     print("position done")
     print("try to write 2nd line")
     ser.write(line2.encode())
     print("write done")
-
 
 def open_close_display(line1, line2):
     ser = False
@@ -74,6 +78,6 @@ def open_close_display(line1, line2):
 
 
 if __name__ == '__main__':
-    line1 = u'POS Code Sprint'
-    line2 = u'@ Akretion 2014/07'
+    line1 = u'COOP IT EASY'
+    line2 = u'Courage Nico!'
     open_close_display(line1, line2)

--- a/hw_customer_display/test-scripts/customer-display-test.py
+++ b/hw_customer_display/test-scripts/customer-display-test.py
@@ -17,19 +17,16 @@ try:
 except (ImportError, IOError) as err:
     _logger.debug(err)
 
-DEVICE = '/dev/ttyUSB1'
+DEVICE = '/dev/ttyUSB0'
 DEVICE_RATE = 9600
 DEVICE_COLS = 20
 
+CLEAR_DISPLAY = b'\x0C'
+MOVE_CURSOR_TO = b'\x1B\x6C'
+
+
 
 def display_text(ser, line1, line2):
-    print("before = ", line1)
-    print("before = ", line2)
-    print("convert to ascii")
-    line1 = unidecode(line1)
-    line2 = unidecode(line2)
-    print("after = ", line1)
-    print("after = ", line2)
     print("set lines to the right length (%s)" % DEVICE_COLS)
     for line in [line1, line2]:
         if len(line) < DEVICE_COLS:
@@ -38,24 +35,24 @@ def display_text(ser, line1, line2):
             line = line[0:DEVICE_COLS]
         assert len(line) == DEVICE_COLS, 'Wrong length'
     print("try to clear display")
-    ser.write(b'\x0C')
+    ser.write(CLEAR_DISPLAY)
     print("clear done")
     print("try to position at start of 1st line")
-    l1 = '\x1B\x6C' + chr(1) + chr(1)
-    print(l1)
-    ser.write(l1.encode())
+    l1 = MOVE_CURSOR_TO + chr(1).encode('ascii') + chr(1).encode('ascii')
+    ser.write(l1)
     print("position done")
     print("try to write 1st line")
-    ser.write(line1.encode())
+    ser.write(unidecode(line1).encode('ascii'))
     print("write 1st line done")
     time.sleep(1)
     print("try to position at start of 2nd line")
-    l2 = '\x1B\x6C' + chr(1) + chr(2)
-    ser.write(l2.encode())
+    l2 = MOVE_CURSOR_TO + chr(1).encode('ascii') + chr(2).encode('ascii')
+    ser.write(l2)
     print("position done")
     print("try to write 2nd line")
-    ser.write(line2.encode())
+    ser.write(unidecode(line2).encode('ascii'))
     print("write done")
+
 
 def open_close_display(line1, line2):
     ser = False
@@ -78,6 +75,6 @@ def open_close_display(line1, line2):
 
 
 if __name__ == '__main__':
-    line1 = u'COOP IT EASY'
-    line2 = u'Courage Nico!'
+    line1 = u'Coop IT Easy'
+    line2 = u'Migration to 12.0'
     open_close_display(line1, line2)


### PR DESCRIPTION
@robinkeunen 
@PierrickBrun 
Migration **fonctionnelle** du module hw_customer_display de 8.0 à 12.0.
**Remarques** : 

- Je n'ai pas encore suivi en détail les recommandations OCA vers [9.0](https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-9.0), [10.0](https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-10.0),  [11.0](https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-11.0) et [12.0](https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-12.0) 

**Question :** 

- Que faire des divers copyrights présents et où intégrer le notre? 
 


