### PR TITLE
[IMP] pos_hash_cert / search for certified modules directory

### DIFF
--- a/pos_hash_cert/models/pos_hash_cert.py
+++ b/pos_hash_cert/models/pos_hash_cert.py
@@ -1,8 +1,15 @@
+import logging
+import os
+
 from odoo import api, fields, models
-from odoo.modules.module import get_module_path
+from odoo.tools.config import config
 
 from checksumdir import dirhash
 
+_logger = logging.getLogger(__name__)
+
+CERT_DIR = config.get('certified_modules_directory', 'pos_certified_modules')
+USER_DIR = os.path.expanduser("~")
 
 class ModuleHash(models.Model):
     _inherit = 'ir.module.module'
@@ -12,15 +19,40 @@ class ModuleHash(models.Model):
 
     @api.multi
     def _compute_hash(self):
-        whitelist = [
-            'pos_container',
-            'pos_customer_display',
-            'pos_customer_display_currency',
-            'pos_hash_cert',
-            'pos_toledo_container',
-            'pos_toledo_product',
-        ]
-        for record in self:
-            if record.name in whitelist:
-                module_path = get_module_path(record.name)
-                record.hash = dirhash(module_path, 'sha256', excluded_extensions=['pyc'])
+
+        start_dir = os.path.dirname(os.path.realpath(__file__))
+        last_root = start_dir
+        current_root = start_dir
+        found_cert_dir = None
+
+        while found_cert_dir is None and current_root != USER_DIR:
+            pruned = False
+            for root, dirs, files in os.walk(current_root):
+                if not pruned:
+                    try:
+                        # Remove the part of the tree we already searched
+                        del dirs[dirs.index(os.path.basename(last_root))]
+                        pruned = True
+                    except ValueError:
+                        pass
+                if CERT_DIR in dirs:
+                    # found the directory, stop
+                    found_cert_dir = os.path.join(root, CERT_DIR)
+                    break
+                # Otherwise, pop up a level, search again
+            last_root = current_root
+            current_root = os.path.dirname(last_root)
+
+        if found_cert_dir:
+            certified_modules = [
+                name
+                for name in os.listdir(found_cert_dir)
+                if os.path.isdir(os.path.join(found_cert_dir, name))
+            ]
+
+            for record in self:
+                if record.name in certified_modules:
+                    record.hash = dirhash(found_cert_dir, 'sha256', excluded_extensions=['pyc'])
+        else:
+            # TODO
+            pass

--- a/pos_hash_cert/models/pos_hash_cert.py
+++ b/pos_hash_cert/models/pos_hash_cert.py
@@ -11,6 +11,7 @@ _logger = logging.getLogger(__name__)
 CERT_DIR = config.get('certified_modules_directory', 'pos_certified_modules')
 USER_DIR = os.path.expanduser("~")
 
+
 class ModuleHash(models.Model):
     _inherit = 'ir.module.module'
 


### PR DESCRIPTION
This module searches for a specific directory where certified modules are placed (ie. the one corresponding to the key `certified_modules_directory` in the odoo.conf file or `pos_certified_modules` as default value).

Once the directory is found, an array containing the modules present in this directory is generated (ie. `['pos_container','pos_customer_display','pos_customer_display_currency','pos_hash_cert', 'pos_toledo_container', 'pos_toledo_product']`).

When iterating the recordset, a hash value is set when the record name matches one of the certified modules array.