### PR TITLE
12.0 pos_price_to_weight: choose price field

### DIFF
--- a/pos_price_to_weight/__manifest__.py
+++ b/pos_price_to_weight/__manifest__.py
@@ -17,6 +17,7 @@
     'data': [
         'data/barcode_rule.xml',
         'views/assets.xml',
+        'views/view_pos_config.xml',
     ],
     'demo': [
         'demo/product_product.xml',

--- a/pos_price_to_weight/demo/product_product.xml
+++ b/pos_price_to_weight/demo/product_product.xml
@@ -11,6 +11,8 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="name">Apples (with Price To Weight Barcode)</field>
         <field name="barcode">0212345000007</field>
         <field name="list_price">1.50</field>
+        <field name="available_in_pos">True</field>
+        <field name="to_weigh">True</field>
         <field name="uom_id" ref="uom.product_uom_kgm"/>
         <field name="uom_po_id" ref="uom.product_uom_kgm"/>
     </record>

--- a/pos_price_to_weight/models/__init__.py
+++ b/pos_price_to_weight/models/__init__.py
@@ -1,1 +1,3 @@
 from . import barcode_rule
+from . import pos_config
+from . import product_product

--- a/pos_price_to_weight/models/pos_config.py
+++ b/pos_price_to_weight/models/pos_config.py
@@ -1,0 +1,14 @@
+# Copyright 2020 Coop IT Easy - Manuel Claeys Bouuaert
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class PosConfig(models.Model):
+    _inherit = 'pos.config'
+
+    pos_price_to_weight_price_field_id = fields.Many2one(
+        string="Pos Price To Weight Price Field",
+        comodel_name="ir.model.fields",
+        domain=[("model", "=", "product.product"), ("ttype", "=", "float")],
+    )

--- a/pos_price_to_weight/models/product_product.py
+++ b/pos_price_to_weight/models/product_product.py
@@ -1,0 +1,24 @@
+# Copyright 2020 Coop IT Easy - Manuel Claeys Bouuaert
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+
+class Product(models.Model):
+    _inherit = 'product.product'
+
+    pos_price_to_weight_price = fields.Float(
+        string="Pos Price To Weight Price",
+        compute="_compute_pos_price_to_weight_price",
+    )
+    # Not sure if this can be stored since we don't know which field
+    # a compute should depend on. But not storing might slow the POS down a lot.
+
+    @api.multi
+    def _compute_pos_price_to_weight_price(self):
+        for obj in self:
+            pos_config = self.env["pos.config"].search([("pos_price_to_weight_price_field_id", "!=", False)])
+            if bool(pos_config) & bool(pos_config.pos_price_to_weight_price_field_id):
+                obj.pos_price_to_weight_price = obj[pos_config.pos_price_to_weight_price_field_id.name]
+            else:
+                obj.pos_price_to_weight_price = obj.list_price

--- a/pos_price_to_weight/static/src/js/models.js
+++ b/pos_price_to_weight/static/src/js/models.js
@@ -27,8 +27,8 @@ odoo.define('pos_price_to_weight.models', function (require) {
             }
             var quantity = 0;
             var price = parseFloat(parsed_code.value) || 0;
-            if (price !== 0 && product.price !== 0){
-                quantity = price / product.price;
+            if (price !== 0 && product.list_price !== 0){
+                quantity = price / product.list_price;
             }
             selectedOrder.add_product(product, {quantity:  quantity, merge: false});
             return true;

--- a/pos_price_to_weight/static/src/js/models.js
+++ b/pos_price_to_weight/static/src/js/models.js
@@ -14,6 +14,17 @@ odoo.define('pos_price_to_weight.models', function (require) {
 
     models.PosModel = models.PosModel.extend({
 
+        initialize: function (session, attributes) {
+
+            var product_model = _.find(this.models, function(model){
+                return model.model === 'product.product';
+            });
+            product_model.fields.push('pos_price_to_weight_price');
+
+            // Inheritance
+            return _super_PosModel.initialize.call(this, session, attributes);
+        },
+
         scan_product: function(parsed_code) {
             if (! (parsed_code.type === 'price_to_weight')){
                 // Normal behaviour
@@ -27,8 +38,8 @@ odoo.define('pos_price_to_weight.models', function (require) {
             }
             var quantity = 0;
             var price = parseFloat(parsed_code.value) || 0;
-            if (price !== 0 && product.list_price !== 0){
-                quantity = price / product.list_price;
+            if (price !== 0 && product.pos_price_to_weight_price !== 0){
+                quantity = price / product.pos_price_to_weight_price;
             }
             selectedOrder.add_product(product, {quantity:  quantity, merge: false});
             return true;

--- a/pos_price_to_weight/views/view_pos_config.xml
+++ b/pos_price_to_weight/views/view_pos_config.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2018 Coop IT Easy - Manuel Claeys Bouuaert
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+
+    <record id="view_pos_config_form" model="ir.ui.view">
+        <field name="model">pos.config</field>
+        <field name="inherit_id" ref="point_of_sale.pos_config_view_form"/>
+        <field name="arch" type="xml">
+            <div id="posbox_reference" position="inside">
+                <div class="col-xs-12 col-md-6 o_setting_box" id="pos_price_to_weight">
+                    <div class="o_setting_right_pane">
+                        <label for="pos_price_to_weight_price_field_id"/>
+                        <div class="text-muted">
+                           Price field used when converting scanned weight to price.
+                        </div>
+                        <div class="content-group mt16">
+                            <field name="pos_price_to_weight_price_field_id" colspan="4" nolabel="1" options="{'no_create': True}"/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
`pos_price_to_weight` recomputes the price as `price` (= scanned through barcode) / `list_price`. This PR makes the latter configurable for a POS.

For the review, I am unsure of a couple of things:
- First time working with POS config, please review carefully.
- Feel free to test the additions to the demo data. They are required for making the record available in the POS.
- It would be much more efficient if `product.product` `pos_price_to_weight_price` would be a stored field, but since we don't know which field its compute function should depend on, this seems impossible?

I tried to implement the approach in `product_product.py` in `models.js` first, but couldn't make this work. I'm pitching the idea here -  *sorry for the clunky code*. 
I tried to consult the pos config to find out which field needed to be pushed (stored in `pos_price_to_weight_price_field_id`) and then pushing that field with `product_model.fields.push()`. To acchieve this, I was thinking to use this code in `models.js`:
```js
var pos_price_to_weight_price_field_id_but_then_the_actual_field_name
initialize: function (session, attributes) {
        var self = this;
        _super_PosModel.initialize.apply(this, arguments);

        this.ready.then(function () {
            if (self.config.pos_price_to_weight_price_field_id) {
                pos_price_to_weight_price_field_id_but_then_the_actual_field_name = some_function_to_get_actual_field_name(self.config.pos_price_to_weight_price_field_id)
                });
            }
        });
        var product_model = _.find(this.models, function(model){
            return model.model === 'product.product';
        });
        product_model.fields.push('pos_price_to_weight_price_field_id_but_then_the_actual_field_name');
},
scan_product: function(parsed_code) {
    ...
        quantity = price / product[pos_price_to_weight_price_field_id_but_then_the_actual_field_name]
    ...
}
```
I ran into two problems:
1) In the first step `self.config.pos_price_to_weight_price_field_id` only returned a database ID and string name (e.g. 'Total with VAT') not the actual field name (e.g. `total_with_vat`). Is there a function/way to retrieve the latter?
2) I didn't know in JS how to then call the field I pushed on `product` (to replace `product.list_price`) since the field I pushed was defined by the code. Can this be done with `product[pos_price_to_weight_price_field_id_but_then_the_actual_field_name]`?

Would this be a more interesting approach? Other ideas?